### PR TITLE
Check debug option before logging

### DIFF
--- a/Server.js
+++ b/Server.js
@@ -93,6 +93,8 @@ module.exports = class SMTP extends EventEmitter {
      * @param {...any} data
      */
     debug(data) {
-        if (this.opts.debug === true) console.log.apply(console, ["[SMTP/server]", ...arguments]);
+        if (this.opts.debug) {
+            console.log.apply(console, ["[SMTP/server]", ...arguments]);
+        }
     }
 };

--- a/Server.js
+++ b/Server.js
@@ -65,7 +65,7 @@ module.exports = class SMTP extends EventEmitter {
         // @ts-ignore
         this.ipc.broadcast(
             key,
-            data            
+            data
         );
     }
 
@@ -93,6 +93,6 @@ module.exports = class SMTP extends EventEmitter {
      * @param {...any} data
      */
     debug(data) {
-        console.log.apply(console, ["[SMTP/server]", ...arguments]);
+        if (this.opts.debug === true) console.log.apply(console, ["[SMTP/server]", ...arguments]);
     }
 };


### PR DESCRIPTION
The current version does not respect the debug option that is passed to the SMTP class, and logs everything anyway. This PR adds a check for that option and prevents logging if debug mode isn't enabled. 